### PR TITLE
anfr_hebdo - v26.2r

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
-.env    
-*.html
+.env
 *.csv
 !files/cc_insee/cc_insee.csv
-/maj_hebdo
 *.pyc
-files/compared/timestamp.txt
+files/pretraite/*.txt
+files/compared/*.txt

--- a/compare.py
+++ b/compare.py
@@ -134,7 +134,8 @@ def rename_old_file(old_path, new_path):
 
 def load_and_process_csv(file_path):
     try:
-        df = pd.read_csv(file_path, sep=None, engine='python')
+        sep = functions_anfr.detect_separator(file_path)
+        df = pd.read_csv(file_path, sep=sep, engine='c', on_bad_lines='skip', dtype=str)
         df = df[['adm_lb_nom', 'sup_id', 'emr_lb_systeme', 'nat_id', 'sup_nm_haut', 'tpo_id', 'adr_lb_lieu', 'adr_lb_add1', 'adr_lb_add2', 'adr_lb_add3', 'com_cd_insee', 'coordonnees', 'statut', 'emr_dt']]
         df = df.rename(columns={
             'adm_lb_nom': 'operateur',
@@ -158,7 +159,9 @@ def load_and_process_csv(file_path):
         df['code_insee'] = df['code_insee'].astype(str).str.zfill(5)
         
         # Normaliser coordonnees: format "lat , lon" avec espaces consistants
-        df['coordonnees'] = df['coordonnees'].astype(str).str.replace(r'\s*,\s*', ' , ', regex=True)
+        df['coordonnees'] = (df['coordonnees'].astype(str)
+                            .str.split(r'\s*,\s*', regex=True)
+                            .str.join(' , '))
         
         return df
     except FileNotFoundError:
@@ -207,27 +210,17 @@ def compare_data(df_old, df_current):
         # Lignes supprimées (présentes seulement dans l'ancien CSV)
         df_removed = df_merged[df_merged['statut_last'].isna()]
         
-        def dates_significantly_different(old_date, new_date):
-            if pd.isna(old_date) != pd.isna(new_date):
-                return True
-            if pd.isna(old_date) and pd.isna(new_date):
-                return False
-            try:
-                return str(old_date).strip() != str(new_date).strip()
-            except:
-                return old_date != new_date
-        
-        # Condition pour les modifications de date_activ : uniquement si statut reste "Projet approuvé"
-        def date_activ_changed_for_projet_approuve(row):
-            return (row['statut_old'] == 'Projet approuvé' and 
-                    row['statut_last'] == 'Projet approuvé' and
-                    dates_significantly_different(row['date_activ_old'], row['date_activ_last']))
-        
         # Lignes modifiées : soit le statut a changé, soit la date_activ a changé pour les "Projet approuvé"
-        df_modified = df_merged[
-            (df_merged['statut_old'] != df_merged['statut_last']) | 
-            df_merged.apply(date_activ_changed_for_projet_approuve, axis=1)
-        ]
+        mask_statut = df_merged['statut_old'] != df_merged['statut_last']
+
+        mask_date = (
+            (df_merged['statut_old'] == 'Projet approuvé') &
+            (df_merged['statut_last'] == 'Projet approuvé') &
+            (df_merged['date_activ_old'].fillna('').astype(str).str.strip() !=
+            df_merged['date_activ_last'].fillna('').astype(str).str.strip())
+        )
+
+        df_modified = df_merged[mask_statut | mask_date]
         
         # Supprimer les lignes ajoutées et supprimées des modifications
         df_modified = df_modified.drop(df_removed.index)

--- a/compare.py
+++ b/compare.py
@@ -250,49 +250,123 @@ def write_results(df, file_path, message):
     except IOError as e:
         functions_anfr.log_message(f"Impossible d'écrire dans le fichier '{file_path}' - {e}", "ERROR")
 
-def main(no_file_update, no_download, no_compare, no_write, old_csv_name, new_csv_name, timestamp_a, debug, update_type):
+def main(no_file_update, no_download, no_compare, no_write,
+         old_csv_name, new_csv_name, timestamp_a,
+         debug, update_type):
+
     path_app = os.path.dirname(os.path.abspath(__file__))
     download_path = os.path.join(path_app, 'files', 'from_anfr')
-    url = "https://data.anfr.fr/d4c/api/records/2.0/downloadfile/format=csv&resource_id=88ef0887-6b0f-4d3f-8545-6d64c8f597da&use_labels_for_header=true"
 
-    # Initialiser les variables
+    url = (
+        "https://data.anfr.fr/d4c/api/records/2.0/downloadfile/"
+        "format=csv&resource_id=88ef0887-6b0f-4d3f-8545-6d64c8f597da"
+        "&use_labels_for_header=true"
+    )
+
+    # Initialisation
     curr_csv_path = None
     old_csv_path = None
     current_csv_path = None
     timestamp = None
 
-    if not no_download and not new_csv_name:
-        filename_from_anfr = functions_anfr.get_filename_from_server(url)
-        download_path_r = os.path.join(download_path, filename_from_anfr)
-        functions_anfr.log_message("Début du téléchargement du fichier de data.anfr.fr")
-        curr_csv_path = download_data(url, download_path_r)
-        functions_anfr.log_message("Téléchargement terminé")
-    else:
-        if no_download and not new_csv_name:
-            functions_anfr.log_message("Téléchargement sauté : demandé par argument", "WARN")
-            curr_csv_path = None
-        elif new_csv_name:
-            curr_csv_path = os.path.join(download_path, new_csv_name)
-            functions_anfr.log_message(f"Vous forcez la MAJ avec le current_csv : {curr_csv_path}", "INFO")
+    # ==========================
+    # MODE FORÇAGE COMPLET
+    # ==========================
+    if old_csv_name and new_csv_name:
 
-    if not no_file_update and not old_csv_name:
-        if curr_csv_path:
-            old_csv_path, current_csv_path, timestamp = csv_files_update(curr_csv_path, update_type)
-            functions_anfr.log_message(f"Comparaison entre {old_csv_path} et {current_csv_path}")
+        old_csv_path = os.path.join(download_path, old_csv_name)
+        current_csv_path = os.path.join(download_path, new_csv_name)
+
+        # Pour compatibilité avec le reste du script
+        curr_csv_path = current_csv_path
+
+        timestamp = (
+            str(timestamp_a).strip('"')
+            if timestamp_a
+            else "28/12/2025 à 12:00:00"
+        )
+
+        functions_anfr.log_message(
+            f"Vous forcez la MAJ avec le old_csv : {old_csv_path}",
+            "INFO"
+        )
+
+        functions_anfr.log_message(
+            f"Vous forcez la MAJ avec le new_csv : {current_csv_path}",
+            "INFO"
+        )
+
+        functions_anfr.log_message(
+            f"Vous forcez la MAJ avec le timestamp : {timestamp}",
+            "INFO"
+        )
+
     else:
-        if old_csv_name and new_csv_name:
-            # Mode forçage complet
-            current_csv_path = os.path.join(download_path, new_csv_name)
-            old_csv_path = os.path.join(download_path, old_csv_name)
-            timestamp = str(timestamp_a).strip('\"') if timestamp_a else "28/12/2025 à 12:00:00"
-            functions_anfr.log_message(f"Vous forcez la MAJ avec le old_csv : {old_csv_path}", "INFO")
-            functions_anfr.log_message(f"Vous forcez la MAJ avec le new_csv : {current_csv_path}", "INFO")
-            functions_anfr.log_message(f"Vous forcez la MAJ avec le timestamp : {timestamp}", "INFO")
-        elif no_file_update:
+
+        # ==========================
+        # TELECHARGEMENT
+        # ==========================
+        if not no_download:
+
+            filename_from_anfr = functions_anfr.get_filename_from_server(url)
+
+            download_path_r = os.path.join(
+                download_path,
+                filename_from_anfr
+            )
+
+            functions_anfr.log_message(
+                "Début du téléchargement du fichier de data.anfr.fr"
+            )
+
+            curr_csv_path = download_data(
+                url,
+                download_path_r
+            )
+
+            functions_anfr.log_message(
+                "Téléchargement terminé"
+            )
+
+        else:
+            functions_anfr.log_message(
+                "Téléchargement sauté : demandé par argument",
+                "WARN"
+            )
+
+        # ==========================
+        # SELECTION CSV
+        # ==========================
+        if not no_file_update:
+
+            if curr_csv_path:
+
+                old_csv_path, current_csv_path, timestamp = (
+                    csv_files_update(
+                        curr_csv_path,
+                        update_type
+                    )
+                )
+
+                functions_anfr.log_message(
+                    f"Comparaison entre "
+                    f"{old_csv_path} "
+                    f"et "
+                    f"{current_csv_path}"
+                )
+
+        else:
+
             current_csv_path = curr_csv_path
+
             timestamp = "15/12/2020 à 13:37:37"
-            functions_anfr.log_message(f"Mise à jour des fichiers CSV sautée : vous n'irez pas loin ainsi...", "ERROR")
-            
+
+            functions_anfr.log_message(
+                "Mise à jour des fichiers CSV sautée : "
+                "vous n'irez pas loin ainsi...",
+                "ERROR"
+            )
+
     start_time = time.time()
 
     if not no_compare:

--- a/functions_anfr.py
+++ b/functions_anfr.py
@@ -57,3 +57,12 @@ def get_filename_from_server(url):
     except requests.exceptions.RequestException as e:
         log_message(f"Échec de la récupération du nom du fichier depuis le serveur : {e}", "ERROR")
         raise
+
+def detect_separator(file_path: str) -> str:
+        """Détecte le séparateur CSV sur la première ligne uniquement."""
+        with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
+            first_line = f.readline()
+        for sep in (';', ','):
+            if sep in first_line:
+                return sep
+        return ','  # fallback

--- a/pretrait.py
+++ b/pretrait.py
@@ -205,14 +205,28 @@ class OptimizedProcessor:
             # Fallback si action n'est pas déjà définie
             result.loc[mask_cha] = 'CHA'
         
-        # AJO ou ALL pour comp_added
+        # ==========================
+        # AJO / ALL / AJA
+        # ==========================
+
         mask_ajo = df['source'] == 'comp_added.csv'
 
-        # Cas spécifiques : si statut_y est "En service" ou "Techniquement opérationnel"
-        mask_act = mask_ajo & df['statut_y'].isin(["En service", "Techniquement opérationnel"])
+        mask_activation = (
+            mask_ajo &
+            df['statut_y'].isin([
+                "En service",
+                "Techniquement opérationnel"
+            ])
+        )
 
-        result.loc[mask_act] = 'ALL'
-        result.loc[mask_ajo & ~mask_act] = 'AJO'
+        # Ajout + activation
+        result.loc[mask_activation] = 'AJA'
+
+        # Ajout seul
+        result.loc[
+            mask_ajo &
+            ~mask_activation
+        ] = 'AJO'
 
         
         # SUP pour comp_removed

--- a/pretrait.py
+++ b/pretrait.py
@@ -1137,15 +1137,6 @@ class OptimizedProcessor:
         except Exception as e:
             functions_anfr.log_message(f"Échec lors du traitement des fichiers - {e}", "FATAL")
             raise SystemExit(1)
-        
-def detect_separator(file_path: str) -> str:
-        """Détecte le séparateur CSV sur la première ligne uniquement."""
-        with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
-            first_line = f.readline()
-        for sep in (';', ','):
-            if sep in first_line:
-                return sep
-        return ','  # fallback
 
 
 def main(no_insee, no_process, debug):
@@ -1164,12 +1155,12 @@ def main(no_insee, no_process, debug):
     try:
         # Chargement complet pour extract_tech_dict et build_new_status_map
         functions_anfr.log_message(f"Chargement de {os.path.basename(OLD_CSV_PATH)}...", "INFO")
-        sep_o = detect_separator(OLD_CSV_PATH)
+        sep_o = functions_anfr.detect_separator(OLD_CSV_PATH)
         df_old = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep_o, engine='c')
         functions_anfr.log_message(f"✓ {os.path.basename(OLD_CSV_PATH)} chargé ({len(df_old):,} lignes)", "INFO")
         
         functions_anfr.log_message(f"Chargement de {os.path.basename(NEW_CSV_PATH)}...", "INFO")
-        sep_n = detect_separator(NEW_CSV_PATH)
+        sep_n = functions_anfr.detect_separator(NEW_CSV_PATH)
         df_new = pd.read_csv(NEW_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep_n, engine='c')
         functions_anfr.log_message(f"✓ {os.path.basename(NEW_CSV_PATH)} chargé ({len(df_new):,} lignes)", "INFO")
         

--- a/pretrait.py
+++ b/pretrait.py
@@ -141,7 +141,7 @@ class OptimizedProcessor:
             functions_anfr.log_message("Colonne code_insee manquante", "WARN")
             return (addr_parts + ' 00404 ERR CONV INSEE').str.upper()
     
-    def preprocess_csv_optimized(self, file_path: str, source: str) -> pd.DataFrame:
+    def preprocess_csv_optimized(self, file_path: str, source: str, sep: str) -> pd.DataFrame:
         """Version optimisée du chargement CSV."""
         
         try:
@@ -157,16 +157,15 @@ class OptimizedProcessor:
             suffixed_cols = [
                 'statut_y', 'date_activ_y'
             ]
-            
-            sep = detect_separator(OLD_CSV_PATH)
-            df_sample = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep, engine='c')
+
+            df_sample = pd.read_csv(file_path, on_bad_lines="skip", dtype=str, sep=sep, engine='c')
             available_cols = df_sample.columns.tolist()
             
             # Prendre les colonnes de base disponibles + les colonnes avec suffixe disponibles
             usecols = [col for col in base_cols + suffixed_cols if col in available_cols]
             
             # Chargement avec les colonnes disponibles seulement
-            df = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep, engine='c')
+            df = pd.read_csv(file_path, on_bad_lines="skip", dtype=str, sep=sep, engine='c')
             df['source'] = source
             
             functions_anfr.log_message(f"Chargement du fichier '{file_path}' terminé avec succès.")
@@ -488,10 +487,10 @@ class OptimizedProcessor:
         """Version optimisée de merge_and_process."""
         try:
             # Chargement optimisé des fichiers
-            added_df = self.preprocess_csv_optimized(added_path, 'comp_added.csv')
-            modified_df = self.preprocess_csv_optimized(modified_path, 'comp_modified.csv')
-            removed_df = self.preprocess_csv_optimized(removed_path, 'comp_removed.csv')
-            
+            added_df = self.preprocess_csv_optimized(added_path, 'comp_added.csv', sep=',')
+            modified_df = self.preprocess_csv_optimized(modified_path, 'comp_modified.csv', sep=',')
+            removed_df = self.preprocess_csv_optimized(removed_path, 'comp_removed.csv', sep=',')
+
             if added_df.empty and modified_df.empty and removed_df.empty:
                 functions_anfr.log_message("Tous les fichiers sont vides.", "FATAL")
                 raise SystemExit(1)
@@ -1170,8 +1169,8 @@ def main(no_insee, no_process, debug):
         functions_anfr.log_message(f"✓ {os.path.basename(OLD_CSV_PATH)} chargé ({len(df_old):,} lignes)", "INFO")
         
         functions_anfr.log_message(f"Chargement de {os.path.basename(NEW_CSV_PATH)}...", "INFO")
-        sep_n = detect_separator(OLD_CSV_PATH)
-        df_new = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep_n, engine='c')
+        sep_n = detect_separator(NEW_CSV_PATH)
+        df_new = pd.read_csv(NEW_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep_n, engine='c')
         functions_anfr.log_message(f"✓ {os.path.basename(NEW_CSV_PATH)} chargé ({len(df_new):,} lignes)", "INFO")
         
         # Vérifier les colonnes nécessaires pour tech extraction

--- a/pretrait.py
+++ b/pretrait.py
@@ -7,7 +7,7 @@ import re
 import functions_anfr
 import numpy as np
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import lru_cache
 from typing import Dict, Set, Tuple, Optional, List
 
@@ -30,6 +30,8 @@ try:
 except (FileNotFoundError, IndexError) as e:
     functions_anfr.log_message(f"Erreur lecture timestamp: {e}", "FATAL")
     raise SystemExit(1)
+
+ACTIVATION_LIMIT_DATE = (datetime.strptime(TIMESTAMP, "%d/%m/%Y à %H:%M:%S")-timedelta(days=28)).strftime("%Y-%m-%d")
 
 # Dictionnaires de correspondance optimisés
 CORRESPONDANCES_TYPE_SUPPORT = {
@@ -219,8 +221,17 @@ class OptimizedProcessor:
             ])
         )
 
-        # Ajout + activation
-        result.loc[mask_activation] = 'AJA'
+        mask_activation_rt = (
+            mask_activation &
+            df['date_activ_y'].notna() &
+            (df['date_activ_y'] < ACTIVATION_LIMIT_DATE)
+        )
+
+        result.loc[mask_activation_rt] = 'AJR'
+        result.loc[
+            mask_activation &
+            ~mask_activation_rt
+        ] = 'AJA'
 
         # Ajout seul
         result.loc[
@@ -264,10 +275,18 @@ class OptimizedProcessor:
                 (statut_y == 'Projet approuvé') &
                 (date_activ_x != date_activ_y)
             )
+
+            cond_art = (
+                (statut_x == 'Projet approuvé') &
+                (statut_y.isin(['Techniquement opérationnel', 'En service'])) &
+                date_activ_y.notna() &
+                (date_activ_y < ACTIVATION_LIMIT_DATE)
+            )
             
             cond_all = (
-                (statut_x == 'Projet approuvé') & 
-                (statut_y.isin(['Techniquement opérationnel', 'En service']))
+                (statut_x == 'Projet approuvé') &
+                (statut_y.isin(['Techniquement opérationnel', 'En service'])) &
+                ~cond_art
             )
             
             cond_ext = (
@@ -279,10 +298,11 @@ class OptimizedProcessor:
             mod_indices = mod_df.index
             result.loc[mod_indices[cond_aav]] = 'AAV'
             result.loc[mod_indices[cond_all & ~cond_aav]] = 'ALL'
+            result.loc[mod_indices[cond_art & ~cond_aav]] = 'ART'
             result.loc[mod_indices[cond_ext & ~cond_aav & ~cond_all]] = 'EXT'
         
         return result.fillna("UNKNOWN")
-    
+
     def extract_tech_dict_optimized(self, df: pd.DataFrame) -> Dict[Tuple[str, str], Set[str]]:
         """Version optimisée d'extract_tech_dict."""
         df_clean = df.dropna(subset=["sup_id", "adm_lb_nom", "emr_lb_systeme"])

--- a/pretrait.py
+++ b/pretrait.py
@@ -6,6 +6,7 @@ import csv
 import re
 import functions_anfr
 import numpy as np
+import math
 from collections import defaultdict
 from datetime import datetime, timedelta
 from functools import lru_cache
@@ -142,6 +143,7 @@ class OptimizedProcessor:
     
     def preprocess_csv_optimized(self, file_path: str, source: str) -> pd.DataFrame:
         """Version optimisée du chargement CSV."""
+        
         try:
             # Colonnes de base toujours présentes
             base_cols = [
@@ -156,15 +158,15 @@ class OptimizedProcessor:
                 'statut_y', 'date_activ_y'
             ]
             
-            # Charger d'abord avec toutes les colonnes pour voir ce qui existe
-            df_sample = pd.read_csv(file_path, nrows=0, sep=None, engine='python')
+            sep = detect_separator(OLD_CSV_PATH)
+            df_sample = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep, engine='c')
             available_cols = df_sample.columns.tolist()
             
             # Prendre les colonnes de base disponibles + les colonnes avec suffixe disponibles
             usecols = [col for col in base_cols + suffixed_cols if col in available_cols]
             
             # Chargement avec les colonnes disponibles seulement
-            df = pd.read_csv(file_path, usecols=usecols, dtype=str, na_filter=True, sep=None, engine='python')
+            df = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep, engine='c')
             df['source'] = source
             
             functions_anfr.log_message(f"Chargement du fichier '{file_path}' terminé avec succès.")
@@ -258,16 +260,10 @@ class OptimizedProcessor:
                 result.loc[mask_mod] = "UNKNOWN"
                 return result.fillna("UNKNOWN")
             
-            # Normalisation des dates avec gestion sécurisée
-            for col in ['date_activ_x', 'date_activ_y']:
-                mod_df[col] = mod_df[col].fillna('').astype(str).str.strip()
-                mod_df[col] = mod_df[col].replace('', None)
-            
-            # Remplacer les valeurs NaN par des chaînes vides pour éviter les erreurs .isin()
-            statut_x = mod_df['statut_x'].fillna('')
-            statut_y = mod_df['statut_y'].fillna('')
-            date_activ_x = mod_df['date_activ_x'].fillna('')
-            date_activ_y = mod_df['date_activ_y'].fillna('')
+            statut_x = mod_df['statut_x']
+            statut_y = mod_df['statut_y']
+            date_activ_x = mod_df['date_activ_x']
+            date_activ_y = mod_df['date_activ_y']
             
             # Conditions vectorisées avec gestion sécurisée des NaN
             cond_aav = (
@@ -308,13 +304,16 @@ class OptimizedProcessor:
         df_clean = df.dropna(subset=["sup_id", "adm_lb_nom", "emr_lb_systeme"])
         if df_clean.empty:
             return {}
+
+        result = defaultdict(set)
+        for sup_id, oper, tech in zip(
+            df_clean["sup_id"],
+            df_clean["adm_lb_nom"],
+            df_clean["emr_lb_systeme"]
+        ):
+            result[(sup_id, oper)].add(tech)
         
-        # Groupby optimisé avec transformation directe
-        grouped = (df_clean.groupby(["sup_id", "adm_lb_nom"])["emr_lb_systeme"]
-                  .apply(lambda x: frozenset(x.unique()))
-                  .to_dict())
-        
-        return {k: set(v) for k, v in grouped.items()}
+        return dict(result)
     
     def format_technology_with_changes(self, techs_str: str, old_value: Optional[str], change_type: str) -> str:
         """Formate le champ technologie en intégrant les anciennes valeurs pour CHA/CHI/CHL.
@@ -521,7 +520,6 @@ class OptimizedProcessor:
                 Utilise la formule de Haversine simplifiée"""
                 if lat1 is None or lat2 is None:
                     return None
-                import math
                 R = 6371000  # Rayon terrestre en mètres
                 dlat = math.radians(lat2 - lat1)
                 dlon = math.radians(lon2 - lon1)
@@ -1140,6 +1138,15 @@ class OptimizedProcessor:
         except Exception as e:
             functions_anfr.log_message(f"Échec lors du traitement des fichiers - {e}", "FATAL")
             raise SystemExit(1)
+        
+def detect_separator(file_path: str) -> str:
+        """Détecte le séparateur CSV sur la première ligne uniquement."""
+        with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
+            first_line = f.readline()
+        for sep in (';', ','):
+            if sep in first_line:
+                return sep
+        return ','  # fallback
 
 
 def main(no_insee, no_process, debug):
@@ -1158,11 +1165,13 @@ def main(no_insee, no_process, debug):
     try:
         # Chargement complet pour extract_tech_dict et build_new_status_map
         functions_anfr.log_message(f"Chargement de {os.path.basename(OLD_CSV_PATH)}...", "INFO")
-        df_old = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=None, engine='python')
+        sep_o = detect_separator(OLD_CSV_PATH)
+        df_old = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep_o, engine='c')
         functions_anfr.log_message(f"✓ {os.path.basename(OLD_CSV_PATH)} chargé ({len(df_old):,} lignes)", "INFO")
         
         functions_anfr.log_message(f"Chargement de {os.path.basename(NEW_CSV_PATH)}...", "INFO")
-        df_new = pd.read_csv(NEW_CSV_PATH, on_bad_lines="skip", dtype=str, sep=None, engine='python')
+        sep_n = detect_separator(OLD_CSV_PATH)
+        df_new = pd.read_csv(OLD_CSV_PATH, on_bad_lines="skip", dtype=str, sep=sep_n, engine='c')
         functions_anfr.log_message(f"✓ {os.path.basename(NEW_CSV_PATH)} chargé ({len(df_new):,} lignes)", "INFO")
         
         # Vérifier les colonnes nécessaires pour tech extraction


### PR DESCRIPTION
- Mise à jour du gitignore (virer les vieilleries + rajouter les .txt qui parasitent un peu le tout)

- Optimisation & corrections de compare.py : 
-- passage de engine=python à engine=c pour les pd.read_csv
-- modifié la détection automatique du séparateur du CSV (code factorisé dans functions_anfr)
-- 2-3 autres optis mineures sur les corrections de lat/long & dates
-- reprise intégrale du système de forçage des MAJs

- Optimisation & ajouts de pretrait.py : 
-- sensiblement la même chose que compare.py : engine=c désormais, nouvelle détection du séparateur CSV
-- ajout des actions AJA, AJR & ART [AJout & Activation ; AJout & activation (Rattrapage) ; Activation (RaTtrapage) respectivement]